### PR TITLE
Advanced history

### DIFF
--- a/Lsh.HC
+++ b/Lsh.HC
@@ -2,54 +2,243 @@
 #define LAMBDA "\xFB"
 #define LAMBDA_CHARCODE 0xFB
 
+#define MAX_LINE_LEN	255
 #define AUTOCOMPLETE_MAX_RESULTS 15
+
+#define HIST_FILE_PATH		"~/LshHistory.TXT.Z"
+#define HIST_MAX_ENTRIES	300
 
 // -------------------------------------
 // History
+/*
+$TR,"History overview"$
+$ID,2$Command history is stored as pointers to MAlloc'd
+strings in a circular buffer. This allows for efficient
+pushing of new entries, as well as simple freeing of
+old entries.
 
-class histent {
-  histent*  next;
-  U8        text[0];
-};
+A new entry is added right-to-left. The oldest entry is
+freed and then replaced with the new. The head is
+decremented, wrapping around to the top of the buffer
+when needed.
 
-histent* history;
+History is saved to/loaded from HIST_FILE_PATH, newest
+commands last.
 
-Bool LoadHistory() {
-  history = NULL;
+$ID,-2$$TR,"Relative history"$
+$ID,2$When a user has a partial string in their line buff, up/down
+will jump to the next/prev entry that starts with that
+substring using a linear search.
+
+Since moving up/down in history will necessarily replace the
+current line buffer, the `seek_str` stores the line buffer any
+time a character is typed or on backspace. It's reset after
+pushing history or resetting the line with esc.
+
+$ID,-2$*/
+
+Bool IsPureWhitespace(U8 *str) {
+  I64 i;
+
+  for (i=0; i<StrLen(str); i++) {
+    switch (str[i]) {
+      case CH_SPACE:
+      case CH_SHIFT_SPACE:
+      case '\t':
+        break;
+      default:
+        return FALSE;
+    }
+  }
   return TRUE;
 }
 
-U0 HistoryPush(U8* line) {
-  if (!line[0])
-    return;
+Bool StrStartsWith(U8 *str, U8 *substr) {
+  // Str starts with substr but not the same str.
+  // Returns TRUE if substr is empty str.
 
-  if (history && !StrCmp(history->text, line))
-    return;
+  I64 i;
+  for (i=0; substr[i] != \0; i++) {
+    if (str[i] != substr[i])
+      return FALSE;
+  }
 
-  I64 len = StrLen(line);
-  histent* ent = MAlloc(sizeof(histent) + len + 1);
-  StrCpy(ent->text, line);
-  ent->next = history;
-  history = ent;
+  // Same len = same str.
+  if (str[i] == \0) {
+    return FALSE;
+  } else {
+    return TRUE;
+  }
+}
+
+I64 WrapI64(I64 n, I64 max) {
+  // Wraps `n` around zero and `max`.
+  return ((n % max) + max) % max;
+}
+
+class History {
+  I64 index;	// Temp index for user.
+  I64 head;	// Start of circular buff.
+  I64 used;	// Elements filled.
+  U8 *buff[HIST_MAX_ENTRIES];
+  U8 seek_str[MAX_LINE_LEN+1];
+};
+
+U8 *HistoryGet(History *h, I64 index) {
+  // Get history at index relative to head.
+
+  if (index == -1)
+    return "";
+
+  I64 i = WrapI64(h->head + index, HIST_MAX_ENTRIES);
+
+  return h->buff[i];
+}
+
+U0 HistoryResetCursor(History *h) {
+  h->index = -1;
+  h->seek_str[0] = \0;
+}
+
+U0 HistoryPush(History *h, U8 *line) {
+  // Push entry and update history.
+
+  if (line[0] != NULL
+    && !IsPureWhitespace(line)
+    && StrCmp(line, HistoryGet(h, 0))
+    && StrLen(line) < MAX_LINE_LEN) {
+
+    I64 final_index = WrapI64(h->head - 1, HIST_MAX_ENTRIES);
+
+    // Free last entry in queue before it's overwritten.
+    // NULL is freeable in HolyC.
+    Free(h->buff[final_index]);
+
+    // Update head and used, then push entry.
+    h->used = ClampI64(h->used+1, 0, HIST_MAX_ENTRIES);
+    h->head = final_index;
+    h->buff[h->head] = MAlloc(StrLen(line)+1);
+    StrCpy(h->buff[h->head], line);
+
+  }
+  HistoryResetCursor(h);
+}
+
+U0 HistoryInit(History *h) {
+  // Init history and load old entries if available.
+
+  I64 i;
+  h->index = -1;
+  h->head = 0;
+  h->used = 0;
+
+  MemSet(h->seek_str, 0, (MAX_LINE_LEN+1)*sizeof(U8));
+  MemSet(h->buff, 0, HIST_MAX_ENTRIES*sizeof(I64));
+
+  // Load previous history.
+  if (FileFind(HIST_FILE_PATH)) {
+    U8 *prev_hist = FileRead(HIST_FILE_PATH);
+    U8 line[MAX_LINE_LEN+1];
+    MemSet(line, 0, sizeof(line));
+
+    I64 last_newline_index = 0;
+
+    for (i=0; i<StrLen(prev_hist); i++) {
+      if (prev_hist[i] == '\n' || prev_hist[i+1] == \0) {
+          last_newline_index = i + 1;
+          HistoryPush(h, line);
+          MemSet(line, 0, sizeof(line));
+      } else {
+          line[i-last_newline_index] = prev_hist[i];
+      }
+    }
+  }
+}
+
+U0 HistorySave(History *h) {
+  // Save history to disk. Newest commands last.
+
+  I64 i;
+
+  // Get len for `str_buff`. Save room for newlines and \0.
+  I64 str_buff_len = 1;
+  for (i=0; i<h->used; i++) {
+    str_buff_len += StrLen(HistoryGet(h, i)) + 1;
+  }
+
+  // Build str.
+  U8 *str_buff = CAlloc(str_buff_len * sizeof(U8));
+  for (i=0; i<h->used; i++) {
+    U8 *entry = HistoryGet(h, h->used-(i+1));
+    StrPrint(str_buff, "%s%s\n", str_buff, entry);
+  }
+
+  FileWrite(HIST_FILE_PATH, str_buff, str_buff_len);
+  Free(str_buff);
+}
+
+U0 HistoryFree(History *h) {
+  // Free history buffer.
+  // NULL ptrs are freeable in HolyC.
+
+  I64 i;
+  for (i=0; i<HIST_MAX_ENTRIES; i++) {
+    Free(h->buff[i]);
+  }
+}
+
+U8 *HistoryCycle(History *h, U8 *line, Bool reverse=FALSE) {
+  // Moves up/down in history. If there's a non-empty str
+  // in `h->seek_str`, it jumps to the next/prev entry that
+  // starts with that substr.
+  // Sets hist index and returns command upon matching.
+
+  I64 i;
+  U8 *entry;
+
+  if (!reverse) {
+    for (i=h->index+1; i<h->used; i++) {
+      entry = HistoryGet(h, i);
+      if (StrStartsWith(entry, h->seek_str)
+          && StrCmp(entry, line)) {
+        h->index = i;
+        return entry;
+      }
+    }
+    // No entries match.
+    return line;
+
+  } else {
+    for (i=h->index-1; i>=0; i--) {
+      entry = HistoryGet(h, i);
+      if (StrStartsWith(entry, h->seek_str)
+          && StrCmp(entry, line)) {
+        h->index = i;
+        return entry;
+      }
+    }
+    // No entries match.
+    h->index = -1;
+    return h->seek_str;
+  }
 }
 
 // -------------------------------------
 // Line input
 
-U8* ReadLine(U8* prompt, I64 (*autocomplete)(U8* buffer) = NULL) {
-  static U8 buf[256];
+U8* ReadLine(U8* prompt, I64 (*autocomplete)(U8* buffer) = NULL,
+	History *history) {
+  static U8 buf[MAX_LINE_LEN+1];
   I64 len = 0;
-  histent* hist = history;
 
   buf[0] = 0;
 
 show_prompt:
-
   DocBottom;
   "" prompt;
   "" buf;
 
-  while (len < 255) {
+  while (len < MAX_LINE_LEN) {
     I64 scan;
     I64 ch = GetKey(&scan, FALSE, FALSE);
 
@@ -57,12 +246,15 @@ show_prompt:
       if (len > 0) {
         '' CH_BACKSPACE;
         --len;
+
+        buf[len] = \0;
+        StrCpy(history->seek_str, buf);
       }
     }
     else if (ch == CH_ESC) {
       len = 0;
-      buf[len] = 0;
-
+      buf[len] = \0;
+      HistoryResetCursor(history);
       EdLineDel(DocPut);
       goto show_prompt;
     }
@@ -70,7 +262,7 @@ show_prompt:
       return 0;
     }
     else if (ch == '\t' && autocomplete) {
-      buf[len] = 0;
+      buf[len] = \0;
 
       // Completing path or last argument?
       U8* start = StrLastOcc(buf, " ");
@@ -93,15 +285,29 @@ show_prompt:
       EdLineDel(DocPut);
       goto show_prompt;
     }
-    else if (ch == 0 && scan.u8[0] == SC_CURSOR_UP) {
-      if (hist) {
-        StrCpy(buf, hist->text);
-        len = StrLen(buf);
-        hist = hist->next;
+    else if (ch == 0) {
+      Bool reverse;
+      I64 move_index_num;
 
-        EdLineDel(DocPut);
-        goto show_prompt;
+      if (scan.u8[0] == SC_CURSOR_UP) {
+        reverse = FALSE;
+        move_index_num = 1;
       }
+      else if (scan.u8[0] == SC_CURSOR_DOWN) {
+        reverse = TRUE;
+        move_index_num = -1;
+      }
+      else {
+        goto skip;
+      }
+
+      buf[len] = \0;
+      StrCpy(buf, HistoryCycle(history, buf, reverse));
+
+      len = StrLen(buf);
+      EdLineDel(DocPut);
+      goto show_prompt;
+      skip:
     }
     else if (ch) {
       '' ch;
@@ -110,9 +316,13 @@ show_prompt:
         break;
 
       buf[len++] = ch;
+      buf[len] = \0; //Make buf a string
+
+      StrCpy(history->seek_str, buf);
     }
   }
-  buf[len] = 0;
+
+  buf[len] = \0;
   return buf;
 }
 
@@ -124,7 +334,7 @@ I64 Tokenize(U8* str, U8** tokens) {
   Bool started = FALSE;
 
   while (*str) {
-    if (*str == ' ') {
+    if (*str == ' ' || *str == CH_SHIFT_SPACE) {
       if (started) {
         *str = 0;
         started = FALSE;
@@ -406,7 +616,7 @@ Bool IsPath(U8* str) {
 
 U8* Prompt() {
   // TODO: Avoid malloc if we can rely on MAX_PATH
-  static U8 buf[200];  
+  static U8 buf[200];
   U8* dir = DirCurShort();
 
   //StrPrint(buf, "$FG,5$" LAMBDA " $FG,8$%s $FG,0$", dir);
@@ -440,7 +650,7 @@ U0 Intro() {
   "$FG,1$- $FG,0$Esc$FG,1$ deletes line\n"
   "$FG,1$- $FG,0$Tab$FG,1$ auto-completes paths\n"
   "$FG,1$- $FG,0$Shift-Esc$FG,1$ quits\n"
-  "$FG,1$- $FG,0$Up Arrow$FG,1$ recalls previous commands\n"
+  "$FG,1$- $FG,0$Up/Down Arrows$FG,1$ cycle through previous commands\n"
   "\n";
 }
 
@@ -492,7 +702,9 @@ U0 ParseAndExecute(U8* line) {
 
 U0 Lsh() {
   PatchFont();
-  LoadHistory();
+
+  History history;
+  HistoryInit(&history);
 
   if (!skip_intro) {
     "$FG,8$Welcome to $FG,5$Lambda Shell$FG,8$!\n";
@@ -501,12 +713,13 @@ U0 Lsh() {
 
   while (1) {
     U8* p = Prompt();
-    U8* line = ReadLine(p, &Autocomplete);
+    U8* line = ReadLine(p, &Autocomplete, &history);
 
     if (!line || !StrCmp(line, "exit"))
       break;
 
-    HistoryPush(line);
+    HistoryPush(&history, line);
+    DCFill;
 
     try {
       ParseAndExecute(line);
@@ -515,6 +728,10 @@ U0 Lsh() {
       PutExcept();
     }
   }
-
+  HistorySave(&history);
+  HistoryFree(&history);
   "$FG$\n";
+  DCFill;
 }
+
+

--- a/Lsh.HC
+++ b/Lsh.HC
@@ -719,7 +719,6 @@ U0 Lsh() {
       break;
 
     HistoryPush(&history, line);
-    DCFill;
 
     try {
       ParseAndExecute(line);
@@ -731,7 +730,4 @@ U0 Lsh() {
   HistorySave(&history);
   HistoryFree(&history);
   "$FG$\n";
-  DCFill;
 }
-
-


### PR DESCRIPTION
History system is redone with a circular buffer instead of a
singly-linked list. Seeking up and down supported. History is written to
a file in the user's home directory on closing, and reloaded on opening.

Supports Fish-style partial history completion.